### PR TITLE
fix json serialisation error; basicpy init task

### DIFF
--- a/src/apx_fractal_task_collection/__FRACTAL_MANIFEST__.json
+++ b/src/apx_fractal_task_collection/__FRACTAL_MANIFEST__.json
@@ -1571,15 +1571,6 @@
             "title": "BaSiCPyModelParams",
             "type": "object"
           },
-          "CorrectBy": {
-            "description": "Enum for BaSiCPy correction options.",
-            "enum": [
-              "wavelength id",
-              "channel label"
-            ],
-            "title": "CorrectBy",
-            "type": "string"
-          },
           "InitArgsBaSiCPyCalculate": {
             "description": "Arguments to be passed from BaSiCPy Calculate init to compute",
             "properties": {
@@ -1588,8 +1579,8 @@
                 "type": "string"
               },
               "correct_by": {
-                "$ref": "#/$defs/CorrectBy",
-                "title": "Correct_By"
+                "title": "Correct By",
+                "type": "string"
               },
               "channel_zarr_urls": {
                 "items": {
@@ -1663,7 +1654,7 @@
         "type": "object",
         "title": "CalculateBasicpyIlluminationModels"
       },
-      "docs_info": "## init_calculate_basicpy_illumination_models\nInitialized BaSiCPy illumination correction task\n\nThis task prepares a parallelization list of all zarr_urls that need to be\nused to perform illumination correction with BaSiCPy.\n## calculate_basicpy_illumination_models\nCalculates illumination correction profiles based on a random sample\nof images of for each channel.\n",
+      "docs_info": "## init_calculate_basicpy_illumination_models\nInitialized BaSiCPy illumination correction task\n\nThis task prepares a parallelization list of all zarr_urls that need to be\nused to perform illumination correction with BaSiCPy.\n## calculate_basicpy_illumination_models\nCalculates illumination correction profiles based on a random sample\nof images for each channel_label or wavelength.\n",
       "docs_link": "https://github.com/Apricot-Therapeutics/APx_fractal_task_collection"
     },
     {
@@ -1712,7 +1703,7 @@
             ],
             "default": "channel label",
             "title": "Correct By",
-            "description": "Defines how illumination correction have been calculated. - channel label: illumination correction has been calculated per channel label - wavelength id: illumination correction has been calculated per wavelength id"
+            "description": "Defines how illumination correction has been calculated. - channel label: illumination correction has been calculated per channel label - wavelength id: illumination correction has been calculated per wavelength id"
           },
           "illumination_exceptions": {
             "items": {
@@ -1720,7 +1711,7 @@
             },
             "title": "Illumination Exceptions",
             "type": "array",
-            "description": "List of channel labels that should not be corrected."
+            "description": "List of channel labels or wavelength ids that should not be corrected."
           },
           "darkfield": {
             "default": true,

--- a/src/apx_fractal_task_collection/io_models.py
+++ b/src/apx_fractal_task_collection/io_models.py
@@ -171,7 +171,7 @@ class InitArgsBaSiCPyCalculate(BaseModel):
     Attributes:
         channel_name: name of the channel for which the illumination model
             will be calculated. can be channel label or wavelength id.
-        correct_by: if illumination profile will be calculated per channel label
+        correct_by: if illumination profile will be calculated per channel_label
             or wavelength id.
         channel_zarr_urls: list of zarr urls specifying the images that
             contain the channel and will be used to calculate the illumination
@@ -187,7 +187,7 @@ class InitArgsBaSiCPyCalculate(BaseModel):
     """
 
     channel_name: str
-    correct_by: CorrectBy
+    correct_by: str
     channel_zarr_urls: list[str]
     channel_zarr_dict: dict[str, int]
     compute_per_well: bool

--- a/src/apx_fractal_task_collection/tasks/apply_basicpy_illumination_models.py
+++ b/src/apx_fractal_task_collection/tasks/apply_basicpy_illumination_models.py
@@ -123,11 +123,11 @@ def apply_basicpy_illumination_models(
         zarr_url: Path or url to the individual OME-Zarr image to be processed.
             (standard argument for Fractal tasks, managed by Fractal server).
         illumination_profiles_folder: Path of folder of illumination profiles.
-        correct_by: Defines how illumination correction have been calculated. 
+        correct_by: Defines how illumination correction has been calculated. 
             - channel label: illumination correction has been calculated per channel label
             - wavelength id: illumination correction has been calculated per wavelength id
-        illumination_exceptions: List of channel labels that should not be
-            corrected.
+        illumination_exceptions: List of channel labels or wavelength ids that 
+            should not be corrected.
         darkfield: If `True`, darkfield correction will be performed.
         input_ROI_table: Name of the ROI table that contains the information
             about the location of the individual field of views (FOVs) to

--- a/src/apx_fractal_task_collection/tasks/calculate_basicpy_illumination_models.py
+++ b/src/apx_fractal_task_collection/tasks/calculate_basicpy_illumination_models.py
@@ -21,7 +21,7 @@ import numpy as np
 from pydantic import Field
 from pydantic import validate_call
 
-from apx_fractal_task_collection.io_models import InitArgsBaSiCPyCalculate, CorrectBy
+from apx_fractal_task_collection.io_models import InitArgsBaSiCPyCalculate
 from apx_fractal_task_collection.utils import BaSiCPyModelParams
 
 from fractal_tasks_core.channels import OmeroChannel
@@ -50,7 +50,7 @@ def calculate_basicpy_illumination_models(
 
     """
     Calculates illumination correction profiles based on a random sample
-    of images of for each channel.
+    of images for each channel_label or wavelength.
 
     Args:
         zarr_url: Path or url to the individual OME-Zarr image to be processed.
@@ -123,7 +123,7 @@ def calculate_basicpy_illumination_models(
                     raise ValueError(
                         "ERROR: inconsistent image sizes in list_indices"
                     )
-        if correct_by == CorrectBy.channel_label:
+        if correct_by == "channel_label":
             tmp_channel: OmeroChannel = get_channel_from_image_zarr(
                 image_zarr_path=zarr_url,
                 wavelength_id=None,

--- a/src/apx_fractal_task_collection/tasks/init_calculate_basicpy_illumination_models.py
+++ b/src/apx_fractal_task_collection/tasks/init_calculate_basicpy_illumination_models.py
@@ -79,7 +79,7 @@ def init_calculate_basicpy_illumination_models(
     logger.info(
         f"Illumination profiles will be calculated based on {correct_by}."
     )
-    
+        
     if correct_by == CorrectBy.channel_label:
         if compute_per_well:
             channel_dict = group_by_well_and_channel(zarr_urls)
@@ -160,7 +160,8 @@ def init_calculate_basicpy_illumination_models(
                 zarr_url=zarr_url,
                 init_args=dict(
                     channel_name=channel,
-                    correct_by=correct_by,
+                    # convert to str to avoid JSON serialization error
+                    correct_by=correct_by.name,
                     channel_zarr_urls=channel_zarr_urls,
                     channel_zarr_dict=channel_zarr_dict,
                     compute_per_well=compute_per_well,


### PR DESCRIPTION
Hey @adrtsc, 

this PR should fix a json serialisation error I got when trying to run 'Calculate BaSiCPy Illumination Models' on Fractal. The tests didn't seem to have caught the bug initially:

`TypeError: Object of type CorrectBy is not JSON serializable
`

I now convert to str in parallelisation list of init task to avoid this error.

:) 

