### PR TITLE
3D illumination correction fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Project metadata (see https://peps.python.org/pep-0621)
 [project]
 name = "apx-fractal-task-collection"
-version = "0.4.3"
+version = "0.4.4"
 description = "A collection of custom fractal tasks."
 readme = "README.md"
 license = { text = "BSD-3-Clause" }
@@ -37,7 +37,7 @@ include = ["apx_fractal_task_collection", "apx_fractal_task_collection.*"]
 
 
 [tool.bumpver]
-current_version = "0.4.3"
+current_version = "0.4.4"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 tag_message = "{new_version}"

--- a/src/apx_fractal_task_collection/__FRACTAL_MANIFEST__.json
+++ b/src/apx_fractal_task_collection/__FRACTAL_MANIFEST__.json
@@ -1719,6 +1719,12 @@
             "type": "boolean",
             "description": "If `True`, darkfield correction will be performed."
           },
+          "baseline": {
+            "default": true,
+            "title": "Baseline",
+            "type": "boolean",
+            "description": "If `True`, baseline subtraction will be performed."
+          },
           "input_ROI_table": {
             "default": "FOV_ROI_table",
             "title": "Input Roi Table",

--- a/src/apx_fractal_task_collection/tasks/calculate_basicpy_illumination_models.py
+++ b/src/apx_fractal_task_collection/tasks/calculate_basicpy_illumination_models.py
@@ -11,7 +11,6 @@
 import logging
 import random
 from pathlib import Path
-from typing import Any
 
 import anndata as ad
 from basicpy import BaSiC
@@ -46,7 +45,7 @@ def calculate_basicpy_illumination_models(
     advanced_basicpy_model_params: BaSiCPyModelParams = Field(
         default_factory=BaSiCPyModelParams),
     overwrite: bool = False,
-) -> dict[str, Any]:
+) -> None:
 
     """
     Calculates illumination correction profiles based on a random sample
@@ -188,10 +187,14 @@ def calculate_basicpy_illumination_models(
         working_size=advanced_basicpy_model_params.working_size,
     )
 
+
     if np.shape(ROI_data)[0] == 1:
+        logger.info(f"ROI data shape is {ROI_data[0, :, :, :].shape}.")
         basic.fit(ROI_data[0, :, :, :])
     else:
+        logger.info(f"ROI data shape is {np.squeeze(ROI_data).shape}.")
         basic.fit(np.squeeze(ROI_data))
+
     logger.info(
         f"Finished calculating illumination correction for channel"
         f" {channel_name}.")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -414,7 +414,7 @@ def test_illumination_correction_by_label(test_data_dir, image_list):
     parallelization_list = init_calculate_basicpy_illumination_models(
         zarr_urls=image_list,
         zarr_dir=test_data_dir,
-        n_images=1,
+        n_images=2,
         correct_by=CorrectBy.channel_label,
         compute_per_well=compute_per_well
     )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -435,6 +435,7 @@ def test_illumination_correction_by_label(test_data_dir, image_list):
         correct_by = CorrectBy.channel_label,
         illumination_exceptions=["0_DAPI"],
         darkfield=True,
+        baseline=True,
         overwrite_input=False,
     )
 
@@ -504,6 +505,7 @@ def test_illumination_correction_by_wavelength(test_data_dir, image_list):
         correct_by = CorrectBy.wavelength_id,
         illumination_exceptions=["Blue - FITC"],
         darkfield=False,
+        baseline=False,
         overwrite_input=False,
     )
 


### PR DESCRIPTION
Hey @adrtsc , 

I really hope this is the last PR for the illumination correction tasks :sweat_smile:

In the 'Apply BaSiCPy Illumination Models' task, the illumination correction currently subtracts a baseline value from the images causing unexpected behaviour in 3D stacks. I now made baseline subtraction optional.

Also, I allowed to reshape the flatfield/darkfield corrections to match the img shape, because this is an edge case that has come up quite often for us 3D peeps (as we typically don't reacquire corrections for every experiment but only every few months).

:) Ruth 