### PR TITLE
Improve docstring of overlap task & add logging

### DIFF
--- a/src/apx_fractal_task_collection/__FRACTAL_MANIFEST__.json
+++ b/src/apx_fractal_task_collection/__FRACTAL_MANIFEST__.json
@@ -675,7 +675,7 @@
                   }
                 ],
                 "title": "Window",
-                "description": "Optional `Window` object to set default display settings for napari."
+                "description": "Optional `Window` object to set default display settings. If unset, it will be set to the full bit range of the image (e.g. 0-65535 for 16 bit images)."
               },
               "color": {
                 "title": "Color",
@@ -937,7 +937,7 @@
                   }
                 ],
                 "title": "Window",
-                "description": "Optional `Window` object to set default display settings for napari."
+                "description": "Optional `Window` object to set default display settings. If unset, it will be set to the full bit range of the image (e.g. 0-65535 for 16 bit images)."
               },
               "color": {
                 "title": "Color",
@@ -1231,7 +1231,7 @@
           "child_table_name": {
             "title": "Child Table Name",
             "type": "string",
-            "description": "Name of the feature table associated with the child label image."
+            "description": "Name of the feature table associated with the child label image. This feature table already needs to exist and the overlap is added to that table."
           },
           "level": {
             "default": 0,


### PR DESCRIPTION
@adrtsc We had some confusion where a user misunderstood what the `child_table_name` variable means. I added a suggestion to improve the docstring as well as additional logging in the task. Specifically, I think it would be very helpful to get log messages when images are skipped. Otherwise, the task can run "successfully" while just skipping all images, because the `child_table_name` does not exist yet.

I'd have separate concerns on why we need to loop over all images in the well in this task, but I guess that's to handle some multiplexing complexities about which cycles will have the feature tables. Thus, I suggest we just update the docstrings and logging for now.