### PR TITLE
Support Python 3.12 pandas installs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-latest]
         python-version: ["3.11"]
+        include:
+          - os: ubuntu-22.04
+            python-version: "3.12"
         exclude:
           - os: macos-latest
             python-version: '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["fractal-tasks-core==1.4.3", "scikit-image >= 0.26.0", "matplotl
                 "basicpy", 'minisom', 'phenograph', "scikit-learn<1.7", "tifffile==2025.1.10",
                 "jax==0.4.23", "jaxlib==0.4.23", "SimpleITK-SimpleElastix", "ome-zarr", "ashlar", "pyfeats",
                 "pydantic>=2.0,<2.8.0", "defusedxml", "seaborn", "numcodecs==0.13.1", "fractal-task-tools==0.1.0", "hyperactive==4.8.0",
-				"dask==2024.2.0", "zarr==2.17.0", "numpy<2", "ml-dtypes==0.5.1", "h5py==3.14.0", "PyWavelets<=1.5.0", "pandas<2.0.0",
+				"dask==2024.2.0", "zarr==2.17.0", "numpy<2", "ml-dtypes==0.5.1", "h5py==3.14.0", "PyWavelets<=1.5.0", "pandas<2.0.0; python_version<'3.12'", "pandas>=2.1.0,<3.0.0; python_version>='3.12'",
                 "contourpy<=1.2.0", "leidenalg==0.10.2", "gradient_free_optimizers<1.9.0"]
 
 # Optional dependencies (e.g. for `pip install -e ".[dev]"`, see


### PR DESCRIPTION
## Description

Fix Python 3.12 installation by keeping `pandas<2` for Python versions before 3.12 while allowing pandas 2.x on Python 3.12 and newer. This avoids the pandas 1.5.x source build path that fails while importing `pkg_resources`.

The CI matrix also gets a Linux Python 3.12 job so the reported install path is covered remotely.

## Related Tickets & Documents

- Closes #37

- [x] I clicked on "Allow edits from maintainers"

## Validation

- Not run locally
- CI pending maintainer approval
