### PR TITLE
Limit zarr URL logging

### DIFF
--- a/src/apx_fractal_task_collection/tasks/init_calculate_basicpy_illumination_models.py
+++ b/src/apx_fractal_task_collection/tasks/init_calculate_basicpy_illumination_models.py
@@ -68,8 +68,8 @@ def init_calculate_basicpy_illumination_models(
             parallelization list.
     """
     logger.info(
-        f"Running `init_calculate_basicpy_illumination_models` "
-        f"for {zarr_urls=}"
+        "Running `init_calculate_basicpy_illumination_models` "
+        f"for {len(zarr_urls)} zarr_urls, starting with {zarr_urls[:10]}"
     )
 
     logger.info(


### PR DESCRIPTION
## Summary
- avoid logging the full `zarr_urls` list in `init_calculate_basicpy_illumination_models`
- log the total count and the first 10 entries instead, so logs stay bounded for large plate runs

## Validation
- `git diff --check HEAD~1..HEAD`
- static review of the changed logging statement
- Tests not run locally

Closes #36